### PR TITLE
add Makefile support to all templates

### DIFF
--- a/templates/console_app/Makefile
+++ b/templates/console_app/Makefile
@@ -1,0 +1,56 @@
+CXX = g++
+OPTIMIZATION_LEVEL = -O2
+
+SRC = $(wildcard src/*.cpp)
+INCLUDES = -Iinclude
+
+# === Debug configuration ===
+DBG_FLAGS = -Wall $(INCLUDES) -g
+DBG_OBJ = $(patsubst src/%.cpp, build/debug/obj/%.o, $(SRC))
+DBG_BIN = build/debug/bin/console_app
+
+# === Release configuration ===
+REL_FLAGS = -Wall $(INCLUDES) $(OPTIMIZATION_LEVEL)
+REL_OBJ = $(patsubst src/%.cpp, build/release/obj/%.o, $(SRC))
+REL_BIN = build/release/bin/console_app
+
+# Link libraries
+LIBS_DEBUG = 
+LIBS_RELEASE = 
+
+all: $(DBG_BIN)
+
+$(DBG_BIN): $(DBG_OBJ)
+	mkdir -p $(dir $@)
+	$(CXX) $(DBG_FLAGS) -o $@ $^ $(LIBS_DEBUG)
+
+build/debug/obj/%.o: src/%.cpp
+	mkdir -p $(dir $@)
+	$(CXX) $(DBG_FLAGS) -c $< -o $@
+
+release: $(REL_BIN)
+
+$(REL_BIN): $(REL_OBJ)
+	mkdir -p $(dir $@)
+	$(CXX) $(REL_FLAGS) -o $@ $^ $(LIBS_RELEASE)
+
+build/release/obj/%.o: src/%.cpp
+	mkdir -p $(dir $@)
+	$(CXX) $(REL_FLAGS) -c $< -o $@
+
+test:
+	mkdir -p build/debug/bin
+	$(CXX) $(DBG_FLAGS) -Itests -o build/debug/bin/test_math tests/test_math.cpp
+	./build/debug/bin/test_math
+
+valgrind: $(DBG_BIN)
+	valgrind --leak-check=full --track-origins=yes ./$(DBG_BIN)
+
+run: $(DBG_BIN)
+	./$(DBG_BIN)
+
+run-release: $(REL_BIN)
+	./$(REL_BIN)
+
+clean:
+	rm -rf build

--- a/templates/console_app/src/main.cpp
+++ b/templates/console_app/src/main.cpp
@@ -2,7 +2,7 @@
 #include "functions.h"
 
 int main() {
-    std::cout << "Hello from {{PROJECT_NAME}}!" << std::endl;
+    std::cout << "Hello from console_app" << std::endl;
     greet();
     
     return 0;

--- a/templates/library_project/Makefile
+++ b/templates/library_project/Makefile
@@ -1,0 +1,71 @@
+CXX = g++
+OPTIMIZATION_LEVEL = -O2
+
+# Source files for the library: all except main.cpp
+SRC = $(filter-out src/main.cpp, $(wildcard src/*.cpp))
+MAIN = src/main.cpp
+
+INCLUDES = -Iinclude
+
+# === Debug configuration ===
+DBG_FLAGS = -Wall $(INCLUDES) -g
+DBG_OBJ = $(patsubst src/%.cpp, build/debug/obj/%.o, $(SRC))
+DBG_LIB = build/debug/lib/liblibrary_project.a
+DBG_BIN = build/debug/bin/main_test
+
+# === Release configuration ===
+REL_FLAGS = -Wall $(INCLUDES) $(OPTIMIZATION_LEVEL)
+REL_OBJ = $(patsubst src/%.cpp, build/release/obj/%.o, $(SRC))
+REL_LIB = build/release/lib/liblibrary_project.a
+REL_BIN = build/release/bin/main_test
+
+all: $(DBG_BIN)
+
+# === Build static library Debug ===
+$(DBG_LIB): $(DBG_OBJ)
+	mkdir -p $(dir $@)
+	ar rcs $@ $^
+
+# === Build test executable Debug ===
+$(DBG_BIN): $(DBG_LIB)
+	mkdir -p $(dir $@)
+	$(CXX) $(DBG_FLAGS) -o $@ $(MAIN) -L$(dir $<) -llibrary_project
+
+build/debug/obj/%.o: src/%.cpp
+	mkdir -p $(dir $@)
+	$(CXX) $(DBG_FLAGS) -c $< -o $@
+
+# === Build static library Release ===
+release: $(REL_BIN)
+
+$(REL_LIB): $(REL_OBJ)
+	mkdir -p $(dir $@)
+	ar rcs $@ $^
+
+# === Build test executable Release ===
+$(REL_BIN): $(REL_LIB)
+	mkdir -p $(dir $@)
+	$(CXX) $(REL_FLAGS) -o $@ $(MAIN) -L$(dir $<) -llibrary_project
+
+build/release/obj/%.o: src/%.cpp
+	mkdir -p $(dir $@)
+	$(CXX) $(REL_FLAGS) -c $< -o $@
+
+# === Run unit tests (example) ===
+test:
+	mkdir -p build/debug/bin
+	$(CXX) $(DBG_FLAGS) -Itests -o build/debug/bin/test_math tests/test_math.cpp
+	./build/debug/bin/test_math
+
+# === Run with valgrind ===
+valgrind: $(DBG_BIN)
+	valgrind --leak-check=full --track-origins=yes ./$(DBG_BIN)
+
+run: $(DBG_BIN)
+	./$(DBG_BIN)
+
+run-release: $(REL_BIN)
+	./$(REL_BIN)
+
+clean:
+	rm -rf build

--- a/templates/opengl_app/Makefile
+++ b/templates/opengl_app/Makefile
@@ -1,0 +1,57 @@
+CXX = g++
+OPTIMIZATION_LEVEL = -O2
+
+SRC = $(wildcard src/*.cpp)
+INCLUDES = -Iinclude
+
+# Libraries for OpenGL 2.1 (Adjust according to your system)
+LIBS_OPENGL = -lGL -lglfw
+
+# === Debug configuration ===
+DBG_FLAGS = -Wall $(INCLUDES) -g
+DBG_OBJ = $(patsubst src/%.cpp, build/debug/obj/%.o, $(SRC))
+DBG_BIN = build/debug/bin/opengl_app
+LIBS_DEBUG = $(LIBS_OPENGL)
+
+# === Release configuration ===
+REL_FLAGS = -Wall $(INCLUDES) $(OPTIMIZATION_LEVEL)
+REL_OBJ = $(patsubst src/%.cpp, build/release/obj/%.o, $(SRC))
+REL_BIN = build/release/bin/opengl_app
+LIBS_RELEASE = $(LIBS_OPENGL)
+
+all: $(DBG_BIN)
+
+$(DBG_BIN): $(DBG_OBJ)
+	mkdir -p $(dir $@)
+	$(CXX) $(DBG_FLAGS) -o $@ $^ $(LIBS_DEBUG)
+
+build/debug/obj/%.o: src/%.cpp
+	mkdir -p $(dir $@)
+	$(CXX) $(DBG_FLAGS) -c $< -o $@
+
+release: $(REL_BIN)
+
+$(REL_BIN): $(REL_OBJ)
+	mkdir -p $(dir $@)
+	$(CXX) $(REL_FLAGS) -o $@ $^ $(LIBS_RELEASE)
+
+build/release/obj/%.o: src/%.cpp
+	mkdir -p $(dir $@)
+	$(CXX) $(REL_FLAGS) -c $< -o $@
+
+test:
+	mkdir -p build/debug/bin
+	$(CXX) $(DBG_FLAGS) -Itests -o build/debug/bin/test_math tests/test_math.cpp
+	./build/debug/bin/test_math
+
+valgrind: $(DBG_BIN)
+	valgrind --leak-check=full --track-origins=yes ./$(DBG_BIN)
+
+run: $(DBG_BIN)
+	./$(DBG_BIN)
+
+run-release: $(REL_BIN)
+	./$(REL_BIN)
+
+clean:
+	rm -rf build

--- a/templates/opengl_app/src/main.cpp
+++ b/templates/opengl_app/src/main.cpp
@@ -17,7 +17,7 @@ int main() {
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
 
-    GLFWwindow* window = glfwCreateWindow(800, 600, "{{PROJECT_NAME}}", nullptr, nullptr);
+    GLFWwindow* window = glfwCreateWindow(800, 600, "opengl_app", nullptr, nullptr);
     if (!window) {
         std::cerr << "Failed to create GLFW window\n";
         glfwTerminate();

--- a/templates/sdl2_app/Makefile
+++ b/templates/sdl2_app/Makefile
@@ -1,0 +1,59 @@
+CXX = g++
+OPTIMIZATION_LEVEL = -O2
+
+SRC = $(wildcard src/*.cpp)
+
+# Automatically get flags and libraries using sdl2-config
+SDL_CFLAGS = $(shell sdl2-config --cflags)
+SDL_LIBS   = $(shell sdl2-config --libs)
+
+INCLUDES = -Iinclude
+
+# === Debug configuration ===
+DBG_FLAGS = -Wall $(INCLUDES) $(SDL_CFLAGS) -g
+DBG_OBJ = $(patsubst src/%.cpp, build/debug/obj/%.o, $(SRC))
+DBG_BIN = build/debug/bin/sdl2_app
+LIBS_DEBUG = $(SDL_LIBS)
+
+# === Release configuration ===
+REL_FLAGS = -Wall $(INCLUDES) $(SDL_CFLAGS) $(OPTIMIZATION_LEVEL)
+REL_OBJ = $(patsubst src/%.cpp, build/release/obj/%.o, $(SRC))
+REL_BIN = build/release/bin/sdl2_app
+LIBS_RELEASE = $(SDL_LIBS)
+
+all: $(DBG_BIN)
+
+$(DBG_BIN): $(DBG_OBJ)
+	mkdir -p $(dir $@)
+	$(CXX) $(DBG_FLAGS) -o $@ $^ $(LIBS_DEBUG)
+
+build/debug/obj/%.o: src/%.cpp
+	mkdir -p $(dir $@)
+	$(CXX) $(DBG_FLAGS) -c $< -o $@
+
+release: $(REL_BIN)
+
+$(REL_BIN): $(REL_OBJ)
+	mkdir -p $(dir $@)
+	$(CXX) $(REL_FLAGS) -o $@ $^ $(LIBS_RELEASE)
+
+build/release/obj/%.o: src/%.cpp
+	mkdir -p $(dir $@)
+	$(CXX) $(REL_FLAGS) -c $< -o $@
+
+test:
+	mkdir -p build/debug/bin
+	$(CXX) $(DBG_FLAGS) -Itests -o build/debug/bin/test_math tests/test_math.cpp
+	./build/debug/bin/test_math
+
+valgrind: $(DBG_BIN)
+	valgrind --leak-check=full --track-origins=yes ./$(DBG_BIN)
+
+run: $(DBG_BIN)
+	./$(DBG_BIN)
+
+run-release: $(REL_BIN)
+	./$(REL_BIN)
+
+clean:
+	rm -rf build

--- a/templates/sfml_app/Makefile
+++ b/templates/sfml_app/Makefile
@@ -1,0 +1,57 @@
+CXX = g++
+OPTIMIZATION_LEVEL = -O2
+
+SRC = $(wildcard src/*.cpp)
+INCLUDES = -Iinclude
+
+# SFML linking flags
+SFML_LIBS = -lsfml-graphics -lsfml-window -lsfml-system
+
+# === Debug configuration ===
+DBG_FLAGS = -Wall $(INCLUDES) -g
+DBG_OBJ = $(patsubst src/%.cpp, build/debug/obj/%.o, $(SRC))
+DBG_BIN = build/debug/bin/sfml_app
+LIBS_DEBUG = $(SFML_LIBS)
+
+# === Release configuration ===
+REL_FLAGS = -Wall $(INCLUDES) $(OPTIMIZATION_LEVEL)
+REL_OBJ = $(patsubst src/%.cpp, build/release/obj/%.o, $(SRC))
+REL_BIN = build/release/bin/sfml_app
+LIBS_RELEASE = $(SFML_LIBS)
+
+all: $(DBG_BIN)
+
+$(DBG_BIN): $(DBG_OBJ)
+	mkdir -p $(dir $@)
+	$(CXX) $(DBG_FLAGS) -o $@ $^ $(LIBS_DEBUG)
+
+build/debug/obj/%.o: src/%.cpp
+	mkdir -p $(dir $@)
+	$(CXX) $(DBG_FLAGS) -c $< -o $@
+
+release: $(REL_BIN)
+
+$(REL_BIN): $(REL_OBJ)
+	mkdir -p $(dir $@)
+	$(CXX) $(REL_FLAGS) -o $@ $^ $(LIBS_RELEASE)
+
+build/release/obj/%.o: src/%.cpp
+	mkdir -p $(dir $@)
+	$(CXX) $(REL_FLAGS) -c $< -o $@
+
+test:
+	mkdir -p build/debug/bin
+	$(CXX) $(DBG_FLAGS) -Itests -o build/debug/bin/test_math tests/test_math.cpp
+	./build/debug/bin/test_math
+
+valgrind: $(DBG_BIN)
+	valgrind --leak-check=full --track-origins=yes ./$(DBG_BIN)
+
+run: $(DBG_BIN)
+	./$(DBG_BIN)
+
+run-release: $(REL_BIN)
+	./$(REL_BIN)
+
+clean:
+	rm -rf build


### PR DESCRIPTION
This PR adds standalone Makefiles to the following templates:
- console_app
- sdl2_app
- sfml_app
- library_project

Each Makefile supports Debug and Release builds, including `run` and `valgrind` targets where applicable.
